### PR TITLE
즐겨찾기 기능 추가 (링크 토글 + 즐겨찾기 목록 분리)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,6 +16,7 @@ model Link {
   description String?
   image String?
   siteName String?
+  isFavorite Boolean @default(false)
   createdAt DateTime @default(now())
   userId  Int
   user  User  @relation(fields: [userId], references:[id])

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -110,7 +110,7 @@ export class AuthController {
       }
     }
 
-    clearAuthCookies(res);
+    clearAuthCookies(res, this.configService);
 
     return { message: '로그아웃되었습니다' };
   }

--- a/backend/src/auth/utils/cookie.ts
+++ b/backend/src/auth/utils/cookie.ts
@@ -46,7 +46,27 @@ export function setAccessTokenCookie(
   });
 }
 
-export function clearAuthCookies(res: Response): void {
-  res.clearCookie('access_token');
-  res.clearCookie('refresh_token');
+export function clearAuthCookies(
+  res: Response,
+  configService: ConfigService,
+): void {
+  const accessTokenExpireMs = configService.get<number>(
+    'ACCESS_TOKEN_EXPIRE_MS',
+  )!;
+
+  const refreshTokenExpireMs = configService.get<number>(
+    'REFRESH_TOKEN_EXPIRE_MS',
+  )!;
+  res.clearCookie('access_token', {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+    maxAge: accessTokenExpireMs,
+  });
+  res.clearCookie('refresh_token', {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+    maxAge: refreshTokenExpireMs,
+  });
 }

--- a/backend/src/link/link.controller.ts
+++ b/backend/src/link/link.controller.ts
@@ -65,6 +65,20 @@ export class LinkController {
     return this.linkService.updateLink(+id, updateLinkDto, userId);
   }
 
+  @Patch(':id/favorite')
+  @UseGuards(JwtAuthGuard)
+  async toggleFavorite(
+    @Param('id') id: string,
+    @Req() req: RequestWithUser,
+  ): Promise<Link> {
+    return this.linkService.toggleFavorite(+id, req.user.id);
+  }
+
+  @Get('favorite')
+  @UseGuards(JwtAuthGuard)
+  async getFavoriteLinks(@Req() req: RequestWithUser): Promise<Link[]> {
+    return this.linkService.getFavoriteLinks(req.user.id);
+  }
   @Get('metadata')
   @UseGuards(JwtAuthGuard)
   async getMetadata(@Query('url') url: string) {

--- a/backend/src/link/link.service.ts
+++ b/backend/src/link/link.service.ts
@@ -47,7 +47,7 @@ export class LinkService {
   async getAllLinksByUserId(userId: number): Promise<Link[]> {
     return await this.prisma.link.findMany({
       where: { userId },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ isFavorite: 'desc' }, { createdAt: 'desc' }],
     });
   }
 
@@ -80,6 +80,24 @@ export class LinkService {
     return this.prisma.link.update({
       where: { id },
       data: dto,
+    });
+  }
+
+  async toggleFavorite(id: number, userId: number): Promise<Link> {
+    const link = await this.prisma.link.findUnique({ where: { id } });
+    if (!link || link.userId !== userId) {
+      throw new ForbiddenException('수정 권한이 없습니다.');
+    }
+    return this.prisma.link.update({
+      where: { id },
+      data: { isFavorite: !link.isFavorite },
+    });
+  }
+
+  async getFavoriteLinks(userId: number): Promise<Link[]> {
+    return await this.prisma.link.findMany({
+      where: { userId, isFavorite: true },
+      orderBy: { createdAt: 'desc' },
     });
   }
 

--- a/backend/src/link/link.service.ts
+++ b/backend/src/link/link.service.ts
@@ -2,6 +2,7 @@ import {
   ConflictException,
   ForbiddenException,
   Injectable,
+  NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateLinkDto } from './dto/create-link.dto';
@@ -51,12 +52,17 @@ export class LinkService {
   }
 
   async deleteLink(id: number, userId: number): Promise<void> {
-    const link = await this.prisma.link.delete({
+    const link = await this.prisma.link.findUnique({
       where: { id },
     });
-    if (!link || link.userId !== userId) {
+    if (!link) {
+      throw new NotFoundException('링크를 찾을 수 없습니다.');
+    }
+
+    if (link.userId !== userId) {
       throw new ForbiddenException('삭제 권한이 없습니다.');
     }
+
     await this.prisma.link.delete({ where: { id } });
   }
 

--- a/frontend/src/components/common/StatsBox.tsx
+++ b/frontend/src/components/common/StatsBox.tsx
@@ -1,11 +1,13 @@
 import { Bookmark, Star, Folder } from 'lucide-react';
 import { useGetLinks } from '../../features/links/hooks/useGetLinks';
+import { useFavoriteLinks } from '../../features/links/hooks/useFavoriteLinks';
 
 export default function StatsBox() {
   const { data: links } = useGetLinks();
+  const { data: favorites } = useFavoriteLinks();
 
-  const total = links?.length;
-  const favoritesCount = 0;
+  const total = links?.length || 0;
+  const favoritesCount = favorites?.length || 0;
   const categoryCount = 0;
   return (
     <div className='grid grid-cols-1 md:grid-cols-3 gap-6 mb-8'>

--- a/frontend/src/features/links/api/linkApi.ts
+++ b/frontend/src/features/links/api/linkApi.ts
@@ -25,3 +25,13 @@ export async function updateLink({
   const response = await apiClient.patch(`/links/${id}`, data);
   return response.data;
 }
+
+export async function toggleFavorite(id: number) {
+  const { data } = await apiClient.patch(`/links/${id}/favorite`);
+  return data;
+}
+
+export async function getFavoriteLinks() {
+  const { data } = await apiClient.get('/links/favorite');
+  return data;
+}

--- a/frontend/src/features/links/components/LinkCard.tsx
+++ b/frontend/src/features/links/components/LinkCard.tsx
@@ -1,9 +1,10 @@
-import { Globe, MoreVertical, ExternalLink } from 'lucide-react';
+import { Globe, MoreVertical, ExternalLink, Bookmark } from 'lucide-react';
 import { useState } from 'react';
 import EditLinkForm from './EditLinkForm';
 import Modal from '../../../components/common/Modal';
 import DropdownMenu from '../../../components/ui/DropdownMenu';
 import type { Link } from '../../../types/link';
+import { useToggleFavorite } from '../hooks/useToggleFavorite';
 
 interface Props {
   link: Link;
@@ -15,9 +16,10 @@ interface Props {
 }
 
 export default function LinkCard({ link, onDelete, onEdit }: Props) {
-  const { id, url, title, description, image, siteName } = link;
+  const { id, url, title, description, image, siteName, isFavorite } = link;
   const [showMenu, setShowMenu] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
+  const { mutate: toggleFavoriteMutate } = useToggleFavorite();
 
   const getDomain = (url: string) => {
     try {
@@ -28,28 +30,23 @@ export default function LinkCard({ link, onDelete, onEdit }: Props) {
   };
 
   return (
-    <li className='group relative bg-gray-800 border border-gray-700 rounded-xl overflow-hidden hover:shadow-lg hover:shadow-black/50 hover:border-gray-600 transition-all duration-300'>
+    <li className='group relative bg-gray-800 border border-gray-700 rounded-xl overflow-visible hover:shadow-lg hover:shadow-black/50 hover:border-gray-600 transition-all duration-300'>
+      {/* 즐겨찾기 버튼 */}
       <div className='absolute top-3 right-3 z-10'>
         <button
-          onClick={() => setShowMenu(!showMenu)}
-          className='p-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-gray-400 hover:text-white transition-all duration-200 opacity-0 group-hover:opacity-100'
+          onClick={() => toggleFavoriteMutate(id)}
+          className='p-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-gray-400 hover:text-yellow-400'
+          title='즐겨찾기'
         >
-          <MoreVertical className='w-4 h-4' />
-        </button>
-        {showMenu && (
-          <DropdownMenu
-            onEdit={() => {
-              setShowMenu(false);
-              setIsEditing(true);
-            }}
-            onDelete={() => {
-              setShowMenu(false);
-              onDelete(id);
-            }}
+          <Bookmark
+            className={`w-4 h-4 ${
+              isFavorite ? 'text-yellow-400' : 'text-gray-400'
+            }`}
           />
-        )}
+        </button>
       </div>
 
+      {/* 링크 전체 영역 */}
       <a
         href={url}
         target='_blank'
@@ -66,16 +63,50 @@ export default function LinkCard({ link, onDelete, onEdit }: Props) {
         </div>
 
         <div className='px-4 sm:px-5 pt-4 sm:pt-5 space-y-2 sm:space-y-3'>
-          {siteName ? (
-            <span className='inline-block text-blue-400 bg-blue-900/30 px-2 py-1 rounded-full text-xs font-medium'>
-              {siteName}
-            </span>
-          ) : (
-            <div className='flex items-center gap-1 text-xs text-gray-400'>
-              <Globe className='w-3 h-3' />
-              <span className='truncate'>{getDomain(url)}</span>
+          {/* siteName + 드롭다운 메뉴 줄 */}
+          <div className='flex items-center justify-between'>
+            {siteName ? (
+              <span className='inline-block text-blue-400 bg-blue-900/30 px-2 py-0.5 rounded-full text-xs font-medium max-w-[70%] truncate'>
+                {siteName}
+              </span>
+            ) : (
+              <div className='flex items-center gap-1 text-xs text-gray-400'>
+                <Globe className='w-3 h-3' />
+                <span className='truncate'>{getDomain(url)}</span>
+              </div>
+            )}
+
+            {/* 드롭다운 버튼 */}
+            <div className='relative z-20'>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault(); // ✅ 링크 이동 방지
+
+                  setShowMenu(!showMenu);
+                }}
+                className='p-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-gray-400 hover:text-white'
+                title='더보기'
+              >
+                <MoreVertical className='w-4 h-4' />
+              </button>
+
+              {showMenu && (
+                <div className='absolute right-0 mt-2'>
+                  <DropdownMenu
+                    onEdit={() => {
+                      setShowMenu(false);
+                      setIsEditing(true);
+                    }}
+                    onDelete={() => {
+                      setShowMenu(false);
+                      onDelete(id);
+                    }}
+                  />
+                </div>
+              )}
             </div>
-          )}
+          </div>
 
           <h3 className='text-white text-base sm:text-lg font-bold line-clamp-2 group-hover/link:text-blue-400 transition-colors duration-200 leading-tight'>
             {title}
@@ -84,6 +115,7 @@ export default function LinkCard({ link, onDelete, onEdit }: Props) {
         </div>
       </a>
 
+      {/* 설명 */}
       <div className='px-4 sm:px-5 pb-4 sm:pb-5 space-y-2'>
         {description && (
           <p className='text-gray-400 text-sm line-clamp-2 leading-relaxed'>
@@ -99,6 +131,7 @@ export default function LinkCard({ link, onDelete, onEdit }: Props) {
         )}
       </div>
 
+      {/* 수정 모달 */}
       {isEditing && (
         <Modal onClose={() => setIsEditing(false)}>
           <EditLinkForm

--- a/frontend/src/features/links/components/LinkList.tsx
+++ b/frontend/src/features/links/components/LinkList.tsx
@@ -1,24 +1,39 @@
 import { useGetLinks } from '../hooks/useGetLinks';
+import { useFavoriteLinks } from '../hooks/useFavoriteLinks';
+import { useDeleteLink } from '../hooks/useDeleteLink';
+import { useUpdateLink } from '../hooks/useUpdateLink';
 import LinkCard from './LinkCard';
 import LoadingSpinner from '../../../components/ui/LoadingSpinner';
 import ErrorMessage from '../../../components/ui/ErrorMessage';
 import EmptyState from '../../../components/ui/EmptyState';
-import { useDeleteLink } from '../hooks/useDeleteLink';
-import { useUpdateLink } from '../hooks/useUpdateLink';
 
-export default function LinkList() {
-  const { data: links, isLoading, error } = useGetLinks();
+interface Props {
+  type: 'all' | 'favorite';
+}
+
+export default function LinkList({ type }: Props) {
+  const {
+    data: allLinks,
+    isLoading: loadingAll,
+    error: errorAll,
+  } = useGetLinks();
+
+  const {
+    data: favoriteLinks,
+    isLoading: loadingFav,
+    error: errorFav,
+  } = useFavoriteLinks();
+
+  const links = type === 'all' ? allLinks : favoriteLinks;
+  const isLoading = type === 'all' ? loadingAll : loadingFav;
+  const error = type === 'all' ? errorAll : errorFav;
+
   const { mutate: deleteLink } = useDeleteLink();
   const { mutate: updateLink } = useUpdateLink();
-  if (isLoading) {
-    return <LoadingSpinner />;
-  }
-  if (error) {
-    return <ErrorMessage message={error.message} />;
-  }
-  if (!links || links.length === 0) {
-    return <EmptyState />;
-  }
+
+  if (isLoading) return <LoadingSpinner />;
+  if (error) return <ErrorMessage message={error.message} />;
+  if (!links || links.length === 0) return <EmptyState />;
 
   return (
     <ul className='space-y-4'>

--- a/frontend/src/features/links/hooks/useFavoriteLinks.ts
+++ b/frontend/src/features/links/hooks/useFavoriteLinks.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getFavoriteLinks } from '../api/linkApi';
+import type { Link } from '../../../types/link';
+
+export function useFavoriteLinks() {
+  return useQuery<Link[]>({
+    queryKey: ['favoriteLinks'],
+    queryFn: getFavoriteLinks,
+  });
+}

--- a/frontend/src/features/links/hooks/useToggleFavorite.ts
+++ b/frontend/src/features/links/hooks/useToggleFavorite.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toggleFavorite } from '../api/linkApi';
+import toast from 'react-hot-toast';
+
+export function useToggleFavorite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: toggleFavorite,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['links'] });
+      queryClient.invalidateQueries({ queryKey: ['favoriteLinks'] });
+      if (data.isFavorite) {
+        toast.success('즐겨찾기에 추가되었습니다!');
+      } else {
+        toast('즐겨찾기에서 제거되었습니다.', { icon: '🗑️' });
+      }
+    },
+    onError: () => {
+      toast.error('즐겨찾기 변경에 실패했습니다.');
+    },
+  });
+}

--- a/frontend/src/pages/links/LinkListView.tsx
+++ b/frontend/src/pages/links/LinkListView.tsx
@@ -1,10 +1,38 @@
+import { useState } from 'react';
 import LinkList from '../../features/links/components/LinkList';
 
+const tabs = [
+  { label: '전체 링크', value: 'all' },
+  { label: '즐겨찾기', value: 'favorite' },
+] as const;
+
 export default function LinkListPage() {
+  const [activeTab, setActiveTab] =
+    useState<(typeof tabs)[number]['value']>('all');
+
   return (
     <div className='max-w-screen-md mx-auto p-4 space-y-6'>
       <h2 className='text-2xl font-bold text-white'>링크 목록</h2>
-      <LinkList />
+
+      {/* 탭 버튼 */}
+      <div className='flex space-x-2'>
+        {tabs.map((tab) => (
+          <button
+            key={tab.value}
+            onClick={() => setActiveTab(tab.value)}
+            className={`px-4 py-2 rounded-full text-sm font-medium ${
+              activeTab === tab.value
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 링크 리스트 */}
+      <LinkList type={activeTab} />
     </div>
   );
 }

--- a/frontend/src/types/link.ts
+++ b/frontend/src/types/link.ts
@@ -5,5 +5,6 @@ export interface Link {
   image: string;
   siteName: string;
   url: string;
+  isFavorite: boolean;
   createdAt: string;
 }


### PR DESCRIPTION
### 구현 내용
- Prisma Link 모델에 isFavorite 필드 추가 및 마이그레이션
- 링크 즐겨찾기 토글 API (`PATCH /link/:id/favorite`)
- 해당 유저의 즐겨찾기 링크 조회 API (`GET /link/favorite`)
- React Query 기반 즐겨찾기 토글 훅 (`useToggleFavorite`)
- LinkCard에 즐겨찾기 버튼 및 상태 표시 UI 추가
- LinkListPage에서 탭 형태로 전체/즐겨찾기 구분
- 각 탭 별 쿼리 분기 (`useGetLinks`, `useFavoriteLinks`)